### PR TITLE
Add project foundation: data layer, Kanban board, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# macOS
+.DS_Store
+
+# Xcode user data
+*.xcuserstate
+xcuserdata/
+
+# Build
+DerivedData/
+build/
+
+# Node sidecar (future)
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,19 @@
 # Hydra
 
-Software project. Currently in early/setup phase.
+macOS native app (Swift + SwiftUI + GRDB). Autonomous AI dev agent with project management.
+
+## Build & Test
+- Xcode project at `hydra.xcodeproj` (not inside a subfolder)
+- Build: `xcodebuild -project hydra.xcodeproj -scheme hydra -destination 'platform=macOS' build`
+- Unit tests only: `xcodebuild test -project hydra.xcodeproj -scheme hydra -destination 'platform=macOS' -only-testing:hydraTests`
+- Tests use in-memory SQLite via `TestDatabase.make()` — no filesystem or app launch needed
+
+## Gotchas
+- Xcode `.pbxproj` can't be edited programmatically — new files must be added to targets manually by the user
+- GRDB: put all protocol conformances (`Codable, FetchableRecord, MutablePersistableRecord`) on the struct declaration, not in extensions — otherwise "circular reference" errors
+- GRDB `belongsTo("x")` looks for a table literally named `x` — use `.references("actual_table")` for snake_case table names
+- `Issue` conflicts with `Testing.Issue` — use `hydra.Issue` in test files
+- Use XCTest (not Swift Testing `import Testing`) for test files
 
 ## Knowledge Base
 Obsidian vault is used for all project notes (architecture, tasks, decisions, etc.).

--- a/hydra.xcodeproj/project.pbxproj
+++ b/hydra.xcodeproj/project.pbxproj
@@ -1,0 +1,629 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		8FCFB2FC2F6592CD0021F95C /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 8FCFB2FB2F6592CD0021F95C /* GRDB */; };
+		8FCFB32B2F6598880021F95C /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 8FCFB32A2F6598880021F95C /* GRDB */; };
+		8FCFB32D2F65988D0021F95C /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 8FCFB32C2F65988D0021F95C /* GRDB */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		8FBBE9A42F658F9C00352E62 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8FBBE98E2F658F9B00352E62 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8FBBE9952F658F9B00352E62;
+			remoteInfo = hydra;
+		};
+		8FBBE9AE2F658F9C00352E62 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8FBBE98E2F658F9B00352E62 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8FBBE9952F658F9B00352E62;
+			remoteInfo = hydra;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		8FBBE9962F658F9B00352E62 /* hydra.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = hydra.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		8FBBE9A32F658F9C00352E62 /* hydraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = hydraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8FBBE9AD2F658F9C00352E62 /* hydraUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = hydraUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		8FBBE9982F658F9B00352E62 /* hydra */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = hydra;
+			sourceTree = "<group>";
+		};
+		8FBBE9A62F658F9C00352E62 /* hydraTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = hydraTests;
+			sourceTree = "<group>";
+		};
+		8FBBE9B02F658F9C00352E62 /* hydraUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = hydraUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8FBBE9932F658F9B00352E62 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8FCFB2FC2F6592CD0021F95C /* GRDB in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8FBBE9A02F658F9C00352E62 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8FCFB32B2F6598880021F95C /* GRDB in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8FBBE9AA2F658F9C00352E62 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8FCFB32D2F65988D0021F95C /* GRDB in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		8FBBE98D2F658F9B00352E62 = {
+			isa = PBXGroup;
+			children = (
+				8FBBE9982F658F9B00352E62 /* hydra */,
+				8FBBE9A62F658F9C00352E62 /* hydraTests */,
+				8FBBE9B02F658F9C00352E62 /* hydraUITests */,
+				8FCFB2FA2F6592CD0021F95C /* Frameworks */,
+				8FBBE9972F658F9B00352E62 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		8FBBE9972F658F9B00352E62 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8FBBE9962F658F9B00352E62 /* hydra.app */,
+				8FBBE9A32F658F9C00352E62 /* hydraTests.xctest */,
+				8FBBE9AD2F658F9C00352E62 /* hydraUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8FCFB2FA2F6592CD0021F95C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8FBBE9952F658F9B00352E62 /* hydra */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8FBBE9B72F658F9C00352E62 /* Build configuration list for PBXNativeTarget "hydra" */;
+			buildPhases = (
+				8FBBE9922F658F9B00352E62 /* Sources */,
+				8FBBE9932F658F9B00352E62 /* Frameworks */,
+				8FBBE9942F658F9B00352E62 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				8FBBE9982F658F9B00352E62 /* hydra */,
+			);
+			name = hydra;
+			packageProductDependencies = (
+				8FCFB2FB2F6592CD0021F95C /* GRDB */,
+			);
+			productName = hydra;
+			productReference = 8FBBE9962F658F9B00352E62 /* hydra.app */;
+			productType = "com.apple.product-type.application";
+		};
+		8FBBE9A22F658F9C00352E62 /* hydraTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8FBBE9BA2F658F9C00352E62 /* Build configuration list for PBXNativeTarget "hydraTests" */;
+			buildPhases = (
+				8FBBE99F2F658F9C00352E62 /* Sources */,
+				8FBBE9A02F658F9C00352E62 /* Frameworks */,
+				8FBBE9A12F658F9C00352E62 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8FBBE9A52F658F9C00352E62 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				8FBBE9A62F658F9C00352E62 /* hydraTests */,
+			);
+			name = hydraTests;
+			packageProductDependencies = (
+				8FCFB32A2F6598880021F95C /* GRDB */,
+			);
+			productName = hydraTests;
+			productReference = 8FBBE9A32F658F9C00352E62 /* hydraTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		8FBBE9AC2F658F9C00352E62 /* hydraUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8FBBE9BD2F658F9C00352E62 /* Build configuration list for PBXNativeTarget "hydraUITests" */;
+			buildPhases = (
+				8FBBE9A92F658F9C00352E62 /* Sources */,
+				8FBBE9AA2F658F9C00352E62 /* Frameworks */,
+				8FBBE9AB2F658F9C00352E62 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8FBBE9AF2F658F9C00352E62 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				8FBBE9B02F658F9C00352E62 /* hydraUITests */,
+			);
+			name = hydraUITests;
+			packageProductDependencies = (
+				8FCFB32C2F65988D0021F95C /* GRDB */,
+			);
+			productName = hydraUITests;
+			productReference = 8FBBE9AD2F658F9C00352E62 /* hydraUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		8FBBE98E2F658F9B00352E62 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2630;
+				LastUpgradeCheck = 2630;
+				TargetAttributes = {
+					8FBBE9952F658F9B00352E62 = {
+						CreatedOnToolsVersion = 26.3;
+					};
+					8FBBE9A22F658F9C00352E62 = {
+						CreatedOnToolsVersion = 26.3;
+						TestTargetID = 8FBBE9952F658F9B00352E62;
+					};
+					8FBBE9AC2F658F9C00352E62 = {
+						CreatedOnToolsVersion = 26.3;
+						TestTargetID = 8FBBE9952F658F9B00352E62;
+					};
+				};
+			};
+			buildConfigurationList = 8FBBE9912F658F9B00352E62 /* Build configuration list for PBXProject "hydra" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 8FBBE98D2F658F9B00352E62;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				8FCFB2E52F6591EC0021F95C /* XCRemoteSwiftPackageReference "GRDB" */,
+				8FCFB2E62F65921A0021F95C /* XCRemoteSwiftPackageReference "SwiftTerm" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 8FBBE9972F658F9B00352E62 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8FBBE9952F658F9B00352E62 /* hydra */,
+				8FBBE9A22F658F9C00352E62 /* hydraTests */,
+				8FBBE9AC2F658F9C00352E62 /* hydraUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		8FBBE9942F658F9B00352E62 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8FBBE9A12F658F9C00352E62 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8FBBE9AB2F658F9C00352E62 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8FBBE9922F658F9B00352E62 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8FBBE99F2F658F9C00352E62 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8FBBE9A92F658F9C00352E62 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		8FBBE9A52F658F9C00352E62 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8FBBE9952F658F9B00352E62 /* hydra */;
+			targetProxy = 8FBBE9A42F658F9C00352E62 /* PBXContainerItemProxy */;
+		};
+		8FBBE9AF2F658F9C00352E62 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8FBBE9952F658F9B00352E62 /* hydra */;
+			targetProxy = 8FBBE9AE2F658F9C00352E62 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		8FBBE9B52F658F9C00352E62 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		8FBBE9B62F658F9C00352E62 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		8FBBE9B82F658F9C00352E62 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dwarfcoders.hydra.hydra;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		8FBBE9B92F658F9C00352E62 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dwarfcoders.hydra.hydra;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		8FBBE9BB2F658F9C00352E62 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dwarfcoders.hydra.hydraTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hydra.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hydra";
+			};
+			name = Debug;
+		};
+		8FBBE9BC2F658F9C00352E62 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dwarfcoders.hydra.hydraTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hydra.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hydra";
+			};
+			name = Release;
+		};
+		8FBBE9BE2F658F9C00352E62 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dwarfcoders.hydra.hydraUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = hydra;
+			};
+			name = Debug;
+		};
+		8FBBE9BF2F658F9C00352E62 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dwarfcoders.hydra.hydraUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = hydra;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8FBBE9912F658F9B00352E62 /* Build configuration list for PBXProject "hydra" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8FBBE9B52F658F9C00352E62 /* Debug */,
+				8FBBE9B62F658F9C00352E62 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8FBBE9B72F658F9C00352E62 /* Build configuration list for PBXNativeTarget "hydra" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8FBBE9B82F658F9C00352E62 /* Debug */,
+				8FBBE9B92F658F9C00352E62 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8FBBE9BA2F658F9C00352E62 /* Build configuration list for PBXNativeTarget "hydraTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8FBBE9BB2F658F9C00352E62 /* Debug */,
+				8FBBE9BC2F658F9C00352E62 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8FBBE9BD2F658F9C00352E62 /* Build configuration list for PBXNativeTarget "hydraUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8FBBE9BE2F658F9C00352E62 /* Debug */,
+				8FBBE9BF2F658F9C00352E62 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		8FCFB2E52F6591EC0021F95C /* XCRemoteSwiftPackageReference "GRDB" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/groue/GRDB.swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
+			};
+		};
+		8FCFB2E62F65921A0021F95C /* XCRemoteSwiftPackageReference "SwiftTerm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/migueldeicaza/SwiftTerm";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.5.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		8FCFB2FB2F6592CD0021F95C /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8FCFB2E52F6591EC0021F95C /* XCRemoteSwiftPackageReference "GRDB" */;
+			productName = GRDB;
+		};
+		8FCFB32A2F6598880021F95C /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8FCFB2E52F6591EC0021F95C /* XCRemoteSwiftPackageReference "GRDB" */;
+			productName = GRDB;
+		};
+		8FCFB32C2F65988D0021F95C /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8FCFB2E52F6591EC0021F95C /* XCRemoteSwiftPackageReference "GRDB" */;
+			productName = GRDB;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 8FBBE98E2F658F9B00352E62 /* Project object */;
+}

--- a/hydra.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/hydra.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/hydra.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/hydra.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "1c8f1272845f29f875fc45d01381d4ffe45c23aec5e1d35f6773ea48bfbcb543",
+  "pins" : [
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift",
+      "state" : {
+        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
+        "version" : "7.10.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swiftterm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "state" : {
+        "revision" : "b1262db5b6bea699a8260a8c66999436c508ca56",
+        "version" : "1.11.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/hydra/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/hydra/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/hydra/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/hydra/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/hydra/Assets.xcassets/Contents.json
+++ b/hydra/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/hydra/Database/AppDatabase.swift
+++ b/hydra/Database/AppDatabase.swift
@@ -1,0 +1,111 @@
+import Foundation
+import GRDB
+
+struct AppDatabase {
+    let dbWriter: any DatabaseWriter
+
+    init(_ dbWriter: any DatabaseWriter) throws {
+        self.dbWriter = dbWriter
+        try migrator.migrate(dbWriter)
+    }
+
+    private var migrator: DatabaseMigrator {
+        var migrator = DatabaseMigrator()
+
+        #if DEBUG
+        migrator.eraseDatabaseOnSchemaChange = true
+        #endif
+
+        migrator.registerMigration("v1") { db in
+            try db.create(table: "projects") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("name", .text).notNull()
+                t.column("description", .text).notNull().defaults(to: "")
+                t.column("defaultAutonomyMode", .text).notNull().defaults(to: "supervised")
+                t.column("createdAt", .datetime).notNull()
+                t.column("updatedAt", .datetime).notNull()
+            }
+
+            try db.create(table: "repositories") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.belongsTo("project", onDelete: .cascade).notNull()
+                t.column("name", .text).notNull()
+                t.column("path", .text).notNull()
+                t.column("createdAt", .datetime).notNull()
+            }
+
+            try db.create(table: "epics") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.belongsTo("project", onDelete: .cascade).notNull()
+                t.column("title", .text).notNull()
+                t.column("description", .text).notNull().defaults(to: "")
+                t.column("createdAt", .datetime).notNull()
+                t.column("updatedAt", .datetime).notNull()
+            }
+
+            try db.create(table: "issues") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.belongsTo("project", onDelete: .cascade).notNull()
+                t.belongsTo("epic", onDelete: .setNull)
+                t.column("title", .text).notNull()
+                t.column("description", .text).notNull().defaults(to: "")
+                t.column("status", .text).notNull().defaults(to: "backlog")
+                t.column("priority", .text).notNull().defaults(to: "medium")
+                t.column("assigneeType", .text).notNull().defaults(to: "human")
+                t.column("assigneeName", .text).notNull().defaults(to: "")
+                t.column("autonomyMode", .text)
+                t.column("createdAt", .datetime).notNull()
+                t.column("updatedAt", .datetime).notNull()
+            }
+
+            try db.create(table: "agent_runs") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.belongsTo("issue", onDelete: .cascade).notNull()
+                t.column("status", .text).notNull().defaults(to: "running")
+                t.column("startedAt", .datetime).notNull()
+                t.column("finishedAt", .datetime)
+                t.column("error", .text)
+            }
+
+            try db.create(table: "agent_steps") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("agentRunId", .integer)
+                    .notNull()
+                    .references("agent_runs", onDelete: .cascade)
+                t.column("orderIndex", .integer).notNull()
+                t.column("description", .text).notNull()
+                t.column("status", .text).notNull().defaults(to: "pending")
+                t.column("output", .text)
+                t.column("filesChanged", .text)
+                t.column("startedAt", .datetime)
+                t.column("finishedAt", .datetime)
+            }
+        }
+
+        return migrator
+    }
+}
+
+extension AppDatabase {
+    static let shared = makeShared()
+
+    private static func makeShared() -> AppDatabase {
+        do {
+            let fileManager = FileManager.default
+            let appSupportURL = try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+            let directoryURL = appSupportURL.appendingPathComponent("Hydra", isDirectory: true)
+            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+            let databaseURL = directoryURL.appendingPathComponent("hydra.sqlite")
+            let dbPool = try DatabasePool(path: databaseURL.path)
+            return try AppDatabase(dbPool)
+        } catch {
+            fatalError("Failed to initialize database: \(error)")
+        }
+    }
+}

--- a/hydra/Models/AgentRun.swift
+++ b/hydra/Models/AgentRun.swift
@@ -1,0 +1,46 @@
+import Foundation
+import GRDB
+
+struct AgentRun: Identifiable, Codable, Equatable, FetchableRecord, MutablePersistableRecord {
+    static let databaseTableName = "agent_runs"
+
+    var id: Int64?
+    var issueId: Int64
+    var status: Status
+    var startedAt: Date
+    var finishedAt: Date?
+    var error: String?
+
+    enum Status: String, Codable {
+        case running
+        case completed
+        case failed
+        case cancelled
+    }
+
+    enum Columns {
+        static let id = Column(CodingKeys.id)
+        static let issueId = Column(CodingKeys.issueId)
+        static let status = Column(CodingKeys.status)
+    }
+
+    init(
+        id: Int64? = nil,
+        issueId: Int64,
+        status: Status = .running,
+        startedAt: Date = Date(),
+        finishedAt: Date? = nil,
+        error: String? = nil
+    ) {
+        self.id = id
+        self.issueId = issueId
+        self.status = status
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.error = error
+    }
+
+    mutating func didInsert(_ inserted: InsertionSuccess) {
+        id = inserted.rowID
+    }
+}

--- a/hydra/Models/AgentStep.swift
+++ b/hydra/Models/AgentStep.swift
@@ -1,0 +1,57 @@
+import Foundation
+import GRDB
+
+struct AgentStep: Identifiable, Codable, Equatable, FetchableRecord, MutablePersistableRecord {
+    static let databaseTableName = "agent_steps"
+
+    var id: Int64?
+    var agentRunId: Int64
+    var orderIndex: Int
+    var description: String
+    var status: Status
+    var output: String?
+    var filesChanged: String?
+    var startedAt: Date?
+    var finishedAt: Date?
+
+    enum Status: String, Codable {
+        case pending
+        case running
+        case completed
+        case failed
+        case skipped
+    }
+
+    enum Columns {
+        static let id = Column(CodingKeys.id)
+        static let agentRunId = Column(CodingKeys.agentRunId)
+        static let orderIndex = Column(CodingKeys.orderIndex)
+        static let status = Column(CodingKeys.status)
+    }
+
+    init(
+        id: Int64? = nil,
+        agentRunId: Int64,
+        orderIndex: Int,
+        description: String,
+        status: Status = .pending,
+        output: String? = nil,
+        filesChanged: String? = nil,
+        startedAt: Date? = nil,
+        finishedAt: Date? = nil
+    ) {
+        self.id = id
+        self.agentRunId = agentRunId
+        self.orderIndex = orderIndex
+        self.description = description
+        self.status = status
+        self.output = output
+        self.filesChanged = filesChanged
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+    }
+
+    mutating func didInsert(_ inserted: InsertionSuccess) {
+        id = inserted.rowID
+    }
+}

--- a/hydra/Models/Epic.swift
+++ b/hydra/Models/Epic.swift
@@ -1,0 +1,39 @@
+import Foundation
+import GRDB
+
+struct Epic: Identifiable, Codable, Equatable, FetchableRecord, MutablePersistableRecord {
+    static let databaseTableName = "epics"
+
+    var id: Int64?
+    var projectId: Int64
+    var title: String
+    var description: String
+    var createdAt: Date
+    var updatedAt: Date
+
+    enum Columns {
+        static let id = Column(CodingKeys.id)
+        static let projectId = Column(CodingKeys.projectId)
+        static let title = Column(CodingKeys.title)
+    }
+
+    init(
+        id: Int64? = nil,
+        projectId: Int64,
+        title: String,
+        description: String = "",
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.projectId = projectId
+        self.title = title
+        self.description = description
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    mutating func didInsert(_ inserted: InsertionSuccess) {
+        id = inserted.rowID
+    }
+}

--- a/hydra/Models/Issue.swift
+++ b/hydra/Models/Issue.swift
@@ -1,0 +1,77 @@
+import Foundation
+import GRDB
+
+struct Issue: Identifiable, Codable, Equatable, FetchableRecord, MutablePersistableRecord {
+    static let databaseTableName = "issues"
+
+    var id: Int64?
+    var projectId: Int64
+    var epicId: Int64?
+    var title: String
+    var description: String
+    var status: Status
+    var priority: Priority
+    var assigneeType: String
+    var assigneeName: String
+    var autonomyMode: String?
+    var createdAt: Date
+    var updatedAt: Date
+
+    enum Status: String, Codable, CaseIterable {
+        case backlog
+        case inProgress = "in_progress"
+        case inReview = "in_review"
+        case done
+    }
+
+    enum Priority: String, Codable, CaseIterable {
+        case urgent
+        case high
+        case medium
+        case low
+    }
+
+    enum Columns {
+        static let id = Column(CodingKeys.id)
+        static let projectId = Column(CodingKeys.projectId)
+        static let epicId = Column(CodingKeys.epicId)
+        static let title = Column(CodingKeys.title)
+        static let status = Column(CodingKeys.status)
+        static let priority = Column(CodingKeys.priority)
+        static let assigneeType = Column(CodingKeys.assigneeType)
+    }
+
+    var isAgentAssigned: Bool { assigneeType == "agent" }
+
+    init(
+        id: Int64? = nil,
+        projectId: Int64,
+        epicId: Int64? = nil,
+        title: String,
+        description: String = "",
+        status: Status = .backlog,
+        priority: Priority = .medium,
+        assigneeType: String = "human",
+        assigneeName: String = "",
+        autonomyMode: String? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.projectId = projectId
+        self.epicId = epicId
+        self.title = title
+        self.description = description
+        self.status = status
+        self.priority = priority
+        self.assigneeType = assigneeType
+        self.assigneeName = assigneeName
+        self.autonomyMode = autonomyMode
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    mutating func didInsert(_ inserted: InsertionSuccess) {
+        id = inserted.rowID
+    }
+}

--- a/hydra/Models/Project.swift
+++ b/hydra/Models/Project.swift
@@ -1,0 +1,47 @@
+import Foundation
+import GRDB
+
+struct Project: Identifiable, Codable, Equatable, FetchableRecord, MutablePersistableRecord {
+    static let databaseTableName = "projects"
+
+    var id: Int64?
+    var name: String
+    var description: String
+    var defaultAutonomyMode: AutonomyMode
+    var createdAt: Date
+    var updatedAt: Date
+
+    enum AutonomyMode: String, Codable, CaseIterable {
+        case supervised
+        case autonomous
+        case chat
+    }
+
+    enum Columns {
+        static let id = Column(CodingKeys.id)
+        static let name = Column(CodingKeys.name)
+        static let defaultAutonomyMode = Column(CodingKeys.defaultAutonomyMode)
+        static let createdAt = Column(CodingKeys.createdAt)
+        static let updatedAt = Column(CodingKeys.updatedAt)
+    }
+
+    init(
+        id: Int64? = nil,
+        name: String,
+        description: String = "",
+        defaultAutonomyMode: AutonomyMode = .supervised,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.defaultAutonomyMode = defaultAutonomyMode
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    mutating func didInsert(_ inserted: InsertionSuccess) {
+        id = inserted.rowID
+    }
+}

--- a/hydra/Models/Repository.swift
+++ b/hydra/Models/Repository.swift
@@ -1,0 +1,37 @@
+import Foundation
+import GRDB
+
+struct Repository: Identifiable, Codable, Equatable, FetchableRecord, MutablePersistableRecord {
+    static let databaseTableName = "repositories"
+
+    var id: Int64?
+    var projectId: Int64
+    var name: String
+    var path: String
+    var createdAt: Date
+
+    enum Columns {
+        static let id = Column(CodingKeys.id)
+        static let projectId = Column(CodingKeys.projectId)
+        static let name = Column(CodingKeys.name)
+        static let path = Column(CodingKeys.path)
+    }
+
+    init(
+        id: Int64? = nil,
+        projectId: Int64,
+        name: String,
+        path: String,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.projectId = projectId
+        self.name = name
+        self.path = path
+        self.createdAt = createdAt
+    }
+
+    mutating func didInsert(_ inserted: InsertionSuccess) {
+        id = inserted.rowID
+    }
+}

--- a/hydra/Views/Board/BoardView.swift
+++ b/hydra/Views/Board/BoardView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct BoardView: View {
+    @State private var viewModel = BoardViewModel()
+    @State private var showingNewIssue = false
+    @State private var newIssueTitle = ""
+    @State private var newIssuePriority: Issue.Priority = .medium
+    @State private var selectedIssue: Issue?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            boardToolbar
+            kanbanBoard
+        }
+        .onAppear {
+            viewModel.ensureProject()
+        }
+        .sheet(isPresented: $showingNewIssue) {
+            newIssueSheet
+        }
+        .sheet(item: $selectedIssue) { issue in
+            IssueDetailView(
+                issue: Binding(
+                    get: { self.selectedIssue ?? issue },
+                    set: { self.selectedIssue = $0 }
+                ),
+                onSave: { updated in
+                    viewModel.updateIssue(updated)
+                },
+                onDelete: { toDelete in
+                    viewModel.deleteIssue(toDelete)
+                }
+            )
+        }
+    }
+
+    private var boardToolbar: some View {
+        HStack {
+            Text("Project Board")
+                .font(.headline)
+            Spacer()
+            Button {
+                showingNewIssue = true
+            } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    private var kanbanBoard: some View {
+        HStack(spacing: 8) {
+            ForEach(viewModel.columns, id: \.self) { status in
+                KanbanColumnView(
+                    status: status,
+                    issues: viewModel.issues(for: status),
+                    onDrop: { issue, newStatus in
+                        viewModel.moveIssue(issue, to: newStatus)
+                    },
+                    onSelect: { issue in
+                        selectedIssue = issue
+                    }
+                )
+            }
+        }
+        .padding(8)
+    }
+
+    private var newIssueSheet: some View {
+        VStack(spacing: 16) {
+            Text("New Issue")
+                .font(.headline)
+
+            TextField("Issue title", text: $newIssueTitle)
+                .textFieldStyle(.roundedBorder)
+
+            Picker("Priority", selection: $newIssuePriority) {
+                ForEach(Issue.Priority.allCases, id: \.self) { p in
+                    Text(p.rawValue.capitalized).tag(p)
+                }
+            }
+
+            HStack {
+                Button("Cancel") {
+                    newIssueTitle = ""
+                    newIssuePriority = .medium
+                    showingNewIssue = false
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button("Create") {
+                    if !newIssueTitle.isEmpty {
+                        viewModel.createIssue(title: newIssueTitle, priority: newIssuePriority)
+                        newIssueTitle = ""
+                        newIssuePriority = .medium
+                        showingNewIssue = false
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(newIssueTitle.isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 350)
+    }
+}

--- a/hydra/Views/Board/BoardViewModel.swift
+++ b/hydra/Views/Board/BoardViewModel.swift
@@ -1,0 +1,99 @@
+import Foundation
+import GRDB
+import Combine
+
+@Observable
+final class BoardViewModel {
+    var issues: [Issue] = []
+    var project: Project?
+
+    private var cancellable: AnyCancellable?
+
+    init() {
+        observeIssues()
+    }
+
+    var columns: [Issue.Status] {
+        Issue.Status.allCases
+    }
+
+    func issues(for status: Issue.Status) -> [Issue] {
+        issues.filter { $0.status == status }
+    }
+
+    func moveIssue(_ issue: Issue, to status: Issue.Status) {
+        guard var updated = issues.first(where: { $0.id == issue.id }) else { return }
+        updated.status = status
+        updated.updatedAt = Date()
+        do {
+            try AppDatabase.shared.dbWriter.write { db in
+                try updated.update(db)
+            }
+        } catch {
+            print("Failed to move issue: \(error)")
+        }
+    }
+
+    func createIssue(title: String, priority: Issue.Priority = .medium) {
+        guard let projectId = project?.id else { return }
+        var issue = Issue(projectId: projectId, title: title, priority: priority)
+        do {
+            try AppDatabase.shared.dbWriter.write { db in
+                try issue.insert(db)
+            }
+        } catch {
+            print("Failed to create issue: \(error)")
+        }
+    }
+
+    func updateIssue(_ issue: Issue) {
+        do {
+            try AppDatabase.shared.dbWriter.write { db in
+                try issue.update(db)
+            }
+        } catch {
+            print("Failed to update issue: \(error)")
+        }
+    }
+
+    func deleteIssue(_ issue: Issue) {
+        do {
+            try AppDatabase.shared.dbWriter.write { db in
+                _ = try issue.delete(db)
+            }
+        } catch {
+            print("Failed to delete issue: \(error)")
+        }
+    }
+
+    func ensureProject() {
+        do {
+            try AppDatabase.shared.dbWriter.write { db in
+                if let existing = try Project.fetchOne(db) {
+                    self.project = existing
+                } else {
+                    var newProject = Project(name: "My Project")
+                    try newProject.insert(db)
+                    self.project = newProject
+                }
+            }
+        } catch {
+            print("Failed to ensure project: \(error)")
+        }
+    }
+
+    private func observeIssues() {
+        let observation = ValueObservation.tracking { db in
+            try Issue.order(Column("createdAt").asc).fetchAll(db)
+        }
+
+        cancellable = observation
+            .publisher(in: AppDatabase.shared.dbWriter, scheduling: .immediate)
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { [weak self] issues in
+                    self?.issues = issues
+                }
+            )
+    }
+}

--- a/hydra/Views/Board/IssueCardView.swift
+++ b/hydra/Views/Board/IssueCardView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct IssueCardView: View {
+    let issue: Issue
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(issue.title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .lineLimit(2)
+                Spacer()
+            }
+
+            HStack(spacing: 8) {
+                priorityBadge
+                assigneeBadge
+            }
+        }
+        .padding(10)
+        .background(.background.secondary)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(.separator, lineWidth: 0.5)
+        )
+    }
+
+    private var priorityBadge: some View {
+        Text(issue.priority.rawValue.capitalized)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(priorityColor.opacity(0.2))
+            .foregroundStyle(priorityColor)
+            .clipShape(Capsule())
+    }
+
+    private var assigneeBadge: some View {
+        HStack(spacing: 3) {
+            Image(systemName: issue.isAgentAssigned ? "cpu" : "person")
+                .font(.caption2)
+            Text(issue.isAgentAssigned ? "Agent" : (issue.assigneeName.isEmpty ? "Unassigned" : issue.assigneeName))
+                .font(.caption2)
+        }
+        .foregroundStyle(.secondary)
+    }
+
+    private var priorityColor: Color {
+        switch issue.priority {
+        case .urgent: .red
+        case .high: .orange
+        case .medium: .blue
+        case .low: .gray
+        }
+    }
+}

--- a/hydra/Views/Board/IssueDetailView.swift
+++ b/hydra/Views/Board/IssueDetailView.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+struct IssueDetailView: View {
+    @Binding var issue: Issue
+    let onSave: (Issue) -> Void
+    let onDelete: (Issue) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var title: String = ""
+    @State private var description: String = ""
+    @State private var status: Issue.Status = .backlog
+    @State private var priority: Issue.Priority = .medium
+    @State private var assigneeType: String = "human"
+    @State private var assigneeName: String = ""
+    @State private var showDeleteConfirm = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            detailToolbar
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    titleSection
+                    statusAndPrioritySection
+                    assigneeSection
+                    descriptionSection
+                }
+                .padding(20)
+            }
+        }
+        .frame(width: 480)
+        .frame(minHeight: 500)
+        .onAppear { loadIssue() }
+        .alert("Delete Issue", isPresented: $showDeleteConfirm) {
+            Button("Delete", role: .destructive) {
+                onDelete(issue)
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Are you sure you want to delete \"\(issue.title)\"?")
+        }
+    }
+
+    // MARK: - Toolbar
+
+    private var detailToolbar: some View {
+        HStack {
+            Text("Issue Detail")
+                .font(.headline)
+            Spacer()
+            Button(role: .destructive) {
+                showDeleteConfirm = true
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            Button("Save") { save() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(.bar)
+    }
+
+    // MARK: - Title
+
+    private var titleSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Title")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            TextField("Issue title", text: $title)
+                .textFieldStyle(.roundedBorder)
+                .font(.title3)
+        }
+    }
+
+    // MARK: - Status & Priority
+
+    private var statusAndPrioritySection: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Status")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Picker("Status", selection: $status) {
+                    ForEach(Issue.Status.allCases, id: \.self) { s in
+                        Text(s.displayName).tag(s)
+                    }
+                }
+                .labelsHidden()
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Priority")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Picker("Priority", selection: $priority) {
+                    ForEach(Issue.Priority.allCases, id: \.self) { p in
+                        HStack {
+                            Circle()
+                                .fill(priorityColor(p))
+                                .frame(width: 8, height: 8)
+                            Text(p.rawValue.capitalized)
+                        }
+                        .tag(p)
+                    }
+                }
+                .labelsHidden()
+            }
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Assignee
+
+    private var assigneeSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Assignee")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 12) {
+                Picker("Type", selection: $assigneeType) {
+                    Text("Human").tag("human")
+                    Text("Agent").tag("agent")
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 160)
+
+                if assigneeType == "human" {
+                    TextField("Name", text: $assigneeName)
+                        .textFieldStyle(.roundedBorder)
+                }
+            }
+        }
+    }
+
+    // MARK: - Description
+
+    private var descriptionSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Description")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            TextEditor(text: $description)
+                .font(.body)
+                .frame(minHeight: 150)
+                .padding(4)
+                .background(.background.secondary)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(.separator, lineWidth: 0.5)
+                )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func loadIssue() {
+        title = issue.title
+        description = issue.description
+        status = issue.status
+        priority = issue.priority
+        assigneeType = issue.assigneeType
+        assigneeName = issue.assigneeName
+    }
+
+    private func save() {
+        issue.title = title
+        issue.description = description
+        issue.status = status
+        issue.priority = priority
+        issue.assigneeType = assigneeType
+        issue.assigneeName = assigneeName
+        issue.updatedAt = Date()
+        onSave(issue)
+        dismiss()
+    }
+
+    private func priorityColor(_ p: Issue.Priority) -> Color {
+        switch p {
+        case .urgent: .red
+        case .high: .orange
+        case .medium: .blue
+        case .low: .gray
+        }
+    }
+}

--- a/hydra/Views/Board/KanbanColumnView.swift
+++ b/hydra/Views/Board/KanbanColumnView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct KanbanColumnView: View {
+    let status: Issue.Status
+    let issues: [Issue]
+    let onDrop: (Issue, Issue.Status) -> Void
+    var onSelect: ((Issue) -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            columnHeader
+                .padding(.horizontal, 8)
+                .padding(.vertical, 10)
+
+            ScrollView {
+                LazyVStack(spacing: 6) {
+                    ForEach(issues) { issue in
+                        IssueCardView(issue: issue)
+                            .onTapGesture { onSelect?(issue) }
+                            .draggable(issue.transferRepresentation) {
+                                IssueCardView(issue: issue)
+                                    .frame(width: 200)
+                                    .opacity(0.8)
+                            }
+                    }
+                }
+                .padding(.horizontal, 8)
+                .padding(.bottom, 8)
+            }
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background(.background.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .dropDestination(for: String.self) { items, _ in
+            guard let idString = items.first, let id = Int64(idString) else { return false }
+            if let issue = issues.first(where: { $0.id == id }) {
+                onDrop(issue, status)
+            } else {
+                let placeholder = Issue(id: id, projectId: 0, title: "")
+                onDrop(placeholder, status)
+            }
+            return true
+        }
+    }
+
+    private var columnHeader: some View {
+        HStack {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+            Text(status.displayName)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            Text("\(issues.count)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 1)
+                .background(.quaternary)
+                .clipShape(Capsule())
+            Spacer()
+        }
+    }
+
+    private var statusColor: Color {
+        switch status {
+        case .backlog: .gray
+        case .inProgress: .blue
+        case .inReview: .orange
+        case .done: .green
+        }
+    }
+}
+
+extension Issue.Status {
+    var displayName: String {
+        switch self {
+        case .backlog: "Backlog"
+        case .inProgress: "In Progress"
+        case .inReview: "In Review"
+        case .done: "Done"
+        }
+    }
+}
+
+extension Issue {
+    var transferRepresentation: String {
+        "\(id ?? 0)"
+    }
+}

--- a/hydra/Views/MainView.swift
+++ b/hydra/Views/MainView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct MainView: View {
+    var body: some View {
+        HSplitView {
+            BoardPane()
+                .frame(minWidth: 300, idealWidth: 400)
+
+            ObservationPane()
+                .frame(minWidth: 250, idealWidth: 350)
+
+            RightPane()
+                .frame(minWidth: 300, idealWidth: 400)
+        }
+        .frame(minWidth: 1000, minHeight: 600)
+    }
+}
+
+// MARK: - Board Pane (Left)
+
+struct BoardPane: View {
+    var body: some View {
+        BoardView()
+    }
+}
+
+// MARK: - Observation Pane (Center)
+
+struct ObservationPane: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header("Observation")
+            Text("File tree, diffs, activity log")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+// MARK: - Right Pane (Terminal + Chat)
+
+struct RightPane: View {
+    var body: some View {
+        VSplitView {
+            VStack(alignment: .leading, spacing: 0) {
+                header("Terminal")
+                Text("SwiftTerm terminal goes here")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .frame(minHeight: 200)
+
+            VStack(alignment: .leading, spacing: 0) {
+                header("Chat")
+                Text("Chat interface goes here")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .frame(minHeight: 200)
+        }
+    }
+}
+
+// MARK: - Shared
+
+private func header(_ title: String) -> some View {
+    Text(title)
+        .font(.headline)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.bar)
+}
+
+#Preview {
+    MainView()
+}

--- a/hydra/hydraApp.swift
+++ b/hydra/hydraApp.swift
@@ -1,0 +1,18 @@
+//
+//  hydraApp.swift
+//  hydra
+//
+//  Created by Alexandru Rosca on 14.03.2026.
+//
+
+import SwiftUI
+
+@main
+struct HydraApp: App {
+    var body: some Scene {
+        WindowGroup {
+            MainView()
+        }
+        .defaultSize(width: 1200, height: 800)
+    }
+}

--- a/hydraTests/AgentRunTests.swift
+++ b/hydraTests/AgentRunTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import GRDB
+@testable import hydra
+
+final class AgentRunTests: XCTestCase {
+
+    private func makeIssueAndDB() throws -> (AppDatabase, hydra.Issue) {
+        let db = try TestDatabase.make()
+        var project = Project(name: "Test")
+        try db.dbWriter.write { dbConn in
+            try project.insert(dbConn)
+        }
+        var issue = hydra.Issue(projectId: project.id!, title: "Test task")
+        try db.dbWriter.write { dbConn in
+            try issue.insert(dbConn)
+        }
+        return (db, issue)
+    }
+
+    func testCreateAgentRun() throws {
+        let (db, issue) = try makeIssueAndDB()
+        try db.dbWriter.write { dbConn in
+            var run = AgentRun(issueId: issue.id!)
+            try run.insert(dbConn)
+
+            XCTAssertNotNil(run.id)
+            XCTAssertEqual(run.status, .running)
+            XCTAssertNil(run.error)
+            XCTAssertNil(run.finishedAt)
+        }
+    }
+
+    func testCompleteAgentRun() throws {
+        let (db, issue) = try makeIssueAndDB()
+        try db.dbWriter.write { dbConn in
+            var run = AgentRun(issueId: issue.id!)
+            try run.insert(dbConn)
+
+            run.status = .completed
+            run.finishedAt = Date()
+            try run.update(dbConn)
+
+            let fetched = try AgentRun.fetchOne(dbConn, key: run.id)
+            XCTAssertEqual(fetched?.status, .completed)
+            XCTAssertNotNil(fetched?.finishedAt)
+        }
+    }
+
+    func testFailAgentRun() throws {
+        let (db, issue) = try makeIssueAndDB()
+        try db.dbWriter.write { dbConn in
+            var run = AgentRun(issueId: issue.id!)
+            try run.insert(dbConn)
+
+            run.status = .failed
+            run.error = "Build failed with exit code 1"
+            run.finishedAt = Date()
+            try run.update(dbConn)
+
+            let fetched = try AgentRun.fetchOne(dbConn, key: run.id)
+            XCTAssertEqual(fetched?.status, .failed)
+            XCTAssertEqual(fetched?.error, "Build failed with exit code 1")
+        }
+    }
+
+    func testCascadeDeleteWithIssue() throws {
+        let (db, issue) = try makeIssueAndDB()
+        try db.dbWriter.write { dbConn in
+            var run = AgentRun(issueId: issue.id!)
+            try run.insert(dbConn)
+            let runId = run.id
+
+            _ = try hydra.Issue.deleteAll(dbConn)
+
+            let fetched = try AgentRun.fetchOne(dbConn, key: runId)
+            XCTAssertNil(fetched)
+        }
+    }
+}

--- a/hydraTests/AgentStepTests.swift
+++ b/hydraTests/AgentStepTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+import GRDB
+@testable import hydra
+
+final class AgentStepTests: XCTestCase {
+
+    private func makeRunAndDB() throws -> (AppDatabase, AgentRun) {
+        let db = try TestDatabase.make()
+        var project = Project(name: "Test")
+        try db.dbWriter.write { dbConn in
+            try project.insert(dbConn)
+        }
+        var issue = hydra.Issue(projectId: project.id!, title: "Task")
+        try db.dbWriter.write { dbConn in
+            try issue.insert(dbConn)
+        }
+        var run = AgentRun(issueId: issue.id!)
+        try db.dbWriter.write { dbConn in
+            try run.insert(dbConn)
+        }
+        return (db, run)
+    }
+
+    func testCreateStep() throws {
+        let (db, run) = try makeRunAndDB()
+        try db.dbWriter.write { dbConn in
+            var step = AgentStep(agentRunId: run.id!, orderIndex: 0, description: "Read file")
+            try step.insert(dbConn)
+
+            XCTAssertNotNil(step.id)
+            XCTAssertEqual(step.status, .pending)
+            XCTAssertNil(step.output)
+        }
+    }
+
+    func testStepLifecycle() throws {
+        let (db, run) = try makeRunAndDB()
+        try db.dbWriter.write { dbConn in
+            var step = AgentStep(agentRunId: run.id!, orderIndex: 0, description: "Edit code")
+            try step.insert(dbConn)
+
+            step.status = .running
+            step.startedAt = Date()
+            try step.update(dbConn)
+
+            step.status = .completed
+            step.output = "Modified 3 files"
+            step.filesChanged = "src/main.swift,src/app.swift,src/util.swift"
+            step.finishedAt = Date()
+            try step.update(dbConn)
+
+            let fetched = try AgentStep.fetchOne(dbConn, key: step.id)
+            XCTAssertEqual(fetched?.status, .completed)
+            XCTAssertEqual(fetched?.output, "Modified 3 files")
+            XCTAssertTrue(fetched?.filesChanged?.contains("main.swift") == true)
+        }
+    }
+
+    func testMultipleStepsOrdered() throws {
+        let (db, run) = try makeRunAndDB()
+        try db.dbWriter.write { dbConn in
+            var step1 = AgentStep(agentRunId: run.id!, orderIndex: 0, description: "Read")
+            var step2 = AgentStep(agentRunId: run.id!, orderIndex: 1, description: "Plan")
+            var step3 = AgentStep(agentRunId: run.id!, orderIndex: 2, description: "Execute")
+            try step1.insert(dbConn)
+            try step2.insert(dbConn)
+            try step3.insert(dbConn)
+
+            let steps = try AgentStep
+                .filter(AgentStep.Columns.agentRunId == run.id!)
+                .order(AgentStep.Columns.orderIndex.asc)
+                .fetchAll(dbConn)
+
+            XCTAssertEqual(steps.count, 3)
+            XCTAssertEqual(steps[0].description, "Read")
+            XCTAssertEqual(steps[1].description, "Plan")
+            XCTAssertEqual(steps[2].description, "Execute")
+        }
+    }
+
+    func testCascadeDeleteWithRun() throws {
+        let (db, run) = try makeRunAndDB()
+        try db.dbWriter.write { dbConn in
+            var step = AgentStep(agentRunId: run.id!, orderIndex: 0, description: "Step")
+            try step.insert(dbConn)
+            let stepId = step.id
+
+            _ = try AgentRun.deleteAll(dbConn)
+
+            let fetched = try AgentStep.fetchOne(dbConn, key: stepId)
+            XCTAssertNil(fetched)
+        }
+    }
+}

--- a/hydraTests/DatabaseMigrationTests.swift
+++ b/hydraTests/DatabaseMigrationTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import GRDB
+@testable import hydra
+
+final class DatabaseMigrationTests: XCTestCase {
+
+    func testMigrationCreatesAllTables() throws {
+        let db = try TestDatabase.make()
+        try db.dbWriter.read { dbConn in
+            let tables = try String.fetchAll(dbConn, sql: """
+                SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name != 'grdb_migrations'
+                ORDER BY name
+            """)
+
+            XCTAssertTrue(tables.contains("projects"))
+            XCTAssertTrue(tables.contains("repositories"))
+            XCTAssertTrue(tables.contains("epics"))
+            XCTAssertTrue(tables.contains("issues"))
+            XCTAssertTrue(tables.contains("agent_runs"))
+            XCTAssertTrue(tables.contains("agent_steps"))
+        }
+    }
+
+    func testMigrationIsIdempotent() throws {
+        let dbQueue = try DatabaseQueue()
+        _ = try AppDatabase(dbQueue)
+        _ = try AppDatabase(dbQueue)
+    }
+}

--- a/hydraTests/EpicTests.swift
+++ b/hydraTests/EpicTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+import GRDB
+@testable import hydra
+
+final class EpicTests: XCTestCase {
+
+    private func makeProjectAndDB() throws -> (AppDatabase, Project) {
+        let db = try TestDatabase.make()
+        var project = Project(name: "Test")
+        try db.dbWriter.write { dbConn in
+            try project.insert(dbConn)
+        }
+        return (db, project)
+    }
+
+    func testCreateEpic() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var epic = Epic(projectId: project.id!, title: "Auth System")
+            try epic.insert(dbConn)
+
+            XCTAssertNotNil(epic.id)
+            XCTAssertEqual(epic.title, "Auth System")
+        }
+    }
+
+    func testLinkIssueToEpic() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var epic = Epic(projectId: project.id!, title: "Auth")
+            try epic.insert(dbConn)
+
+            var issue = hydra.Issue(projectId: project.id!, epicId: epic.id, title: "Login page")
+            try issue.insert(dbConn)
+
+            let fetched = try hydra.Issue.fetchOne(dbConn, key: issue.id)
+            XCTAssertEqual(fetched?.epicId, epic.id)
+        }
+    }
+
+    func testDeleteEpicNullsIssueReference() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var epic = Epic(projectId: project.id!, title: "To Delete")
+            try epic.insert(dbConn)
+
+            var issue = hydra.Issue(projectId: project.id!, epicId: epic.id, title: "Linked")
+            try issue.insert(dbConn)
+
+            _ = try epic.delete(dbConn)
+
+            let fetched = try hydra.Issue.fetchOne(dbConn, key: issue.id)
+            XCTAssertNotNil(fetched)
+            XCTAssertNil(fetched?.epicId)
+        }
+    }
+
+    func testCascadeDeleteWithProject() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var epic = Epic(projectId: project.id!, title: "Orphan test")
+            try epic.insert(dbConn)
+            let epicId = epic.id
+
+            _ = try Project.deleteAll(dbConn)
+
+            let fetched = try Epic.fetchOne(dbConn, key: epicId)
+            XCTAssertNil(fetched)
+        }
+    }
+}

--- a/hydraTests/IssueTests.swift
+++ b/hydraTests/IssueTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+import GRDB
+@testable import hydra
+
+final class IssueTests: XCTestCase {
+
+    private func makeProjectAndDB() throws -> (AppDatabase, Project) {
+        let db = try TestDatabase.make()
+        var project = Project(name: "Test")
+        try db.dbWriter.write { dbConn in
+            try project.insert(dbConn)
+        }
+        return (db, project)
+    }
+
+    func testCreateIssue() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var issue = hydra.Issue(projectId: project.id!, title: "Fix login bug")
+            try issue.insert(dbConn)
+
+            XCTAssertNotNil(issue.id)
+            XCTAssertEqual(issue.title, "Fix login bug")
+            XCTAssertEqual(issue.status, .backlog)
+            XCTAssertEqual(issue.priority, .medium)
+            XCTAssertEqual(issue.assigneeType, "human")
+        }
+    }
+
+    func testIssueDefaults() throws {
+        let issue = hydra.Issue(projectId: 1, title: "Test")
+        XCTAssertEqual(issue.status, .backlog)
+        XCTAssertEqual(issue.priority, .medium)
+        XCTAssertEqual(issue.assigneeType, "human")
+        XCTAssertEqual(issue.assigneeName, "")
+        XCTAssertEqual(issue.description, "")
+        XCTAssertNil(issue.epicId)
+        XCTAssertNil(issue.autonomyMode)
+    }
+
+    func testUpdateIssueStatus() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var issue = hydra.Issue(projectId: project.id!, title: "Task")
+            try issue.insert(dbConn)
+
+            issue.status = .inProgress
+            try issue.update(dbConn)
+
+            let fetched = try hydra.Issue.fetchOne(dbConn, key: issue.id)
+            XCTAssertEqual(fetched?.status, .inProgress)
+        }
+    }
+
+    func testUpdateIssuePriority() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var issue = hydra.Issue(projectId: project.id!, title: "Urgent task", priority: .low)
+            try issue.insert(dbConn)
+
+            issue.priority = .urgent
+            try issue.update(dbConn)
+
+            let fetched = try hydra.Issue.fetchOne(dbConn, key: issue.id)
+            XCTAssertEqual(fetched?.priority, .urgent)
+        }
+    }
+
+    func testAssignIssueToAgent() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var issue = hydra.Issue(projectId: project.id!, title: "Agent task")
+            try issue.insert(dbConn)
+
+            issue.assigneeType = "agent"
+            try issue.update(dbConn)
+
+            let fetched = try hydra.Issue.fetchOne(dbConn, key: issue.id)
+            XCTAssertEqual(fetched?.isAgentAssigned, true)
+        }
+    }
+
+    func testIsAgentAssigned() throws {
+        let agentIssue = hydra.Issue(projectId: 1, title: "A", assigneeType: "agent")
+        XCTAssertTrue(agentIssue.isAgentAssigned)
+
+        let humanIssue = hydra.Issue(projectId: 1, title: "B", assigneeType: "human")
+        XCTAssertFalse(humanIssue.isAgentAssigned)
+    }
+
+    func testDeleteIssue() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var issue = hydra.Issue(projectId: project.id!, title: "To delete")
+            try issue.insert(dbConn)
+            let id = issue.id
+
+            _ = try issue.delete(dbConn)
+
+            let fetched = try hydra.Issue.fetchOne(dbConn, key: id)
+            XCTAssertNil(fetched)
+        }
+    }
+
+    func testFetchIssuesByStatus() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var issue1 = hydra.Issue(projectId: project.id!, title: "Backlog 1")
+            var issue2 = hydra.Issue(projectId: project.id!, title: "Backlog 2")
+            var issue3 = hydra.Issue(projectId: project.id!, title: "In Progress", status: .inProgress)
+            try issue1.insert(dbConn)
+            try issue2.insert(dbConn)
+            try issue3.insert(dbConn)
+
+            let backlogIssues = try hydra.Issue
+                .filter(hydra.Issue.Columns.status == hydra.Issue.Status.backlog.rawValue)
+                .fetchAll(dbConn)
+            XCTAssertEqual(backlogIssues.count, 2)
+
+            let inProgressIssues = try hydra.Issue
+                .filter(hydra.Issue.Columns.status == hydra.Issue.Status.inProgress.rawValue)
+                .fetchAll(dbConn)
+            XCTAssertEqual(inProgressIssues.count, 1)
+        }
+    }
+
+    func testIssueStatusTransitions() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var issue = hydra.Issue(projectId: project.id!, title: "Flow test")
+            try issue.insert(dbConn)
+            XCTAssertEqual(issue.status, .backlog)
+
+            issue.status = .inProgress
+            try issue.update(dbConn)
+
+            issue.status = .inReview
+            try issue.update(dbConn)
+
+            issue.status = .done
+            try issue.update(dbConn)
+
+            let fetched = try hydra.Issue.fetchOne(dbConn, key: issue.id)
+            XCTAssertEqual(fetched?.status, .done)
+        }
+    }
+
+    func testCascadeDeleteWithProject() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var issue = hydra.Issue(projectId: project.id!, title: "Orphan test")
+            try issue.insert(dbConn)
+            let issueId = issue.id
+
+            _ = try Project.deleteAll(dbConn)
+
+            let fetched = try hydra.Issue.fetchOne(dbConn, key: issueId)
+            XCTAssertNil(fetched)
+        }
+    }
+}

--- a/hydraTests/ProjectTests.swift
+++ b/hydraTests/ProjectTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+import GRDB
+@testable import hydra
+
+final class ProjectTests: XCTestCase {
+
+    func testCreateProject() throws {
+        let db = try TestDatabase.make()
+        try db.dbWriter.write { dbConn in
+            var project = Project(name: "Test Project")
+            try project.insert(dbConn)
+
+            XCTAssertNotNil(project.id)
+            XCTAssertEqual(project.name, "Test Project")
+            XCTAssertEqual(project.defaultAutonomyMode, .supervised)
+        }
+    }
+
+    func testFetchProject() throws {
+        let db = try TestDatabase.make()
+        try db.dbWriter.write { dbConn in
+            var project = Project(name: "My App")
+            try project.insert(dbConn)
+
+            let fetched = try Project.fetchOne(dbConn, key: project.id)
+            XCTAssertNotNil(fetched)
+            XCTAssertEqual(fetched?.name, "My App")
+        }
+    }
+
+    func testUpdateProject() throws {
+        let db = try TestDatabase.make()
+        try db.dbWriter.write { dbConn in
+            var project = Project(name: "Old Name")
+            try project.insert(dbConn)
+
+            project.name = "New Name"
+            project.defaultAutonomyMode = .autonomous
+            try project.update(dbConn)
+
+            let fetched = try Project.fetchOne(dbConn, key: project.id)
+            XCTAssertEqual(fetched?.name, "New Name")
+            XCTAssertEqual(fetched?.defaultAutonomyMode, .autonomous)
+        }
+    }
+
+    func testDeleteProject() throws {
+        let db = try TestDatabase.make()
+        try db.dbWriter.write { dbConn in
+            var project = Project(name: "To Delete")
+            try project.insert(dbConn)
+            let id = project.id
+
+            _ = try project.delete(dbConn)
+
+            let fetched = try Project.fetchOne(dbConn, key: id)
+            XCTAssertNil(fetched)
+        }
+    }
+
+    func testProjectDefaults() throws {
+        let project = Project(name: "Defaults")
+        XCTAssertEqual(project.description, "")
+        XCTAssertEqual(project.defaultAutonomyMode, .supervised)
+        XCTAssertNil(project.id)
+    }
+}

--- a/hydraTests/RepositoryTests.swift
+++ b/hydraTests/RepositoryTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+import GRDB
+@testable import hydra
+
+final class RepositoryTests: XCTestCase {
+
+    private func makeProjectAndDB() throws -> (AppDatabase, Project) {
+        let db = try TestDatabase.make()
+        var project = Project(name: "Test")
+        try db.dbWriter.write { dbConn in
+            try project.insert(dbConn)
+        }
+        return (db, project)
+    }
+
+    func testCreateRepository() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var repo = Repository(projectId: project.id!, name: "frontend", path: "/code/frontend")
+            try repo.insert(dbConn)
+
+            XCTAssertNotNil(repo.id)
+            XCTAssertEqual(repo.name, "frontend")
+            XCTAssertEqual(repo.path, "/code/frontend")
+        }
+    }
+
+    func testMultipleReposPerProject() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var repo1 = Repository(projectId: project.id!, name: "frontend", path: "/code/fe")
+            var repo2 = Repository(projectId: project.id!, name: "backend", path: "/code/be")
+            try repo1.insert(dbConn)
+            try repo2.insert(dbConn)
+
+            let repos = try Repository
+                .filter(Repository.Columns.projectId == project.id!)
+                .fetchAll(dbConn)
+            XCTAssertEqual(repos.count, 2)
+        }
+    }
+
+    func testCascadeDeleteWithProject() throws {
+        let (db, project) = try makeProjectAndDB()
+        try db.dbWriter.write { dbConn in
+            var repo = Repository(projectId: project.id!, name: "api", path: "/code/api")
+            try repo.insert(dbConn)
+            let repoId = repo.id
+
+            _ = try Project.deleteAll(dbConn)
+
+            let fetched = try Repository.fetchOne(dbConn, key: repoId)
+            XCTAssertNil(fetched)
+        }
+    }
+}

--- a/hydraTests/TestDatabase.swift
+++ b/hydraTests/TestDatabase.swift
@@ -1,0 +1,10 @@
+import Foundation
+import GRDB
+@testable import hydra
+
+enum TestDatabase {
+    static func make() throws -> AppDatabase {
+        let dbQueue = try DatabaseQueue(configuration: .init())
+        return try AppDatabase(dbQueue)
+    }
+}

--- a/hydraTests/hydraTests.swift
+++ b/hydraTests/hydraTests.swift
@@ -1,0 +1,2 @@
+// Individual test files are in this directory.
+// See ProjectTests, IssueTests, EpicTests, etc.

--- a/hydraUITests/hydraUITests.swift
+++ b/hydraUITests/hydraUITests.swift
@@ -1,0 +1,41 @@
+//
+//  hydraUITests.swift
+//  hydraUITests
+//
+//  Created by Alexandru Rosca on 14.03.2026.
+//
+
+import XCTest
+
+final class hydraUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/hydraUITests/hydraUITestsLaunchTests.swift
+++ b/hydraUITests/hydraUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  hydraUITestsLaunchTests.swift
+//  hydraUITests
+//
+//  Created by Alexandru Rosca on 14.03.2026.
+//
+
+import XCTest
+
+final class hydraUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## Summary
- Set up Xcode project with SwiftUI, GRDB 7.10.0, and SwiftTerm 1.11.2 as SPM dependencies
- Implement SQLite data layer with 6 models: Project, Repository, Epic, Issue, AgentRun, AgentStep
- Build three-pane shell layout (Board | Observation | Terminal+Chat) using HSplitView/VSplitView
- Build functional Kanban board with 4 columns, drag-and-drop, issue detail editing, and reactive UI via GRDB ValueObservation
- Add 32 unit tests covering all models, CRUD operations, cascade deletes, and database migrations

## Test plan
- [x] All 32 unit tests pass (`xcodebuild test -only-testing:hydraTests`)
- [x] App launches with three-pane layout
- [x] Issues can be created via + button with priority selection
- [x] Issues can be dragged between Kanban columns
- [x] Issue detail sheet opens on card click, edits persist
- [x] Database migrations run correctly on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)