### PR TITLE
Add Swift protocol types for sidecar communication

### DIFF
--- a/hydra/Services/SidecarProtocol.swift
+++ b/hydra/Services/SidecarProtocol.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - Permission Mode
 
 enum PermissionMode: String, Codable {
-    case `default` = "default"
+    case `default`
     case acceptEdits = "acceptEdits"
     case bypassPermissions = "bypassPermissions"
 }
@@ -177,13 +177,25 @@ enum AgentEvent: Decodable, Equatable {
 
 // MARK: - AnyCodableValue (for untyped JSON results)
 
-enum AnyCodableValue: Decodable, Equatable {
+enum AnyCodableValue: Codable, Equatable {
     case string(String)
     case number(Double)
     case bool(Bool)
     case dictionary([String: AnyCodableValue])
     case array([AnyCodableValue])
     case null
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let val): try container.encode(val)
+        case .number(let val): try container.encode(val)
+        case .bool(let val): try container.encode(val)
+        case .dictionary(let val): try container.encode(val)
+        case .array(let val): try container.encode(val)
+        case .null: try container.encodeNil()
+        }
+    }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/hydraTests/SidecarProtocolTests.swift
+++ b/hydraTests/SidecarProtocolTests.swift
@@ -561,6 +561,46 @@ final class SidecarProtocolTests: XCTestCase {
         }
     }
 
+    // MARK: - AnyCodableValue encoding round-trip
+
+    func testAnyCodableValueEncodesString() throws {
+        let value = AnyCodableValue.string("hello")
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodableValue.self, from: data)
+        XCTAssertEqual(decoded, value)
+    }
+
+    func testAnyCodableValueEncodesNumber() throws {
+        let value = AnyCodableValue.number(3.14)
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodableValue.self, from: data)
+        XCTAssertEqual(decoded, value)
+    }
+
+    func testAnyCodableValueEncodesBool() throws {
+        let value = AnyCodableValue.bool(true)
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodableValue.self, from: data)
+        XCTAssertEqual(decoded, value)
+    }
+
+    func testAnyCodableValueEncodesNestedStructure() throws {
+        let value = AnyCodableValue.dictionary([
+            "names": .array([.string("a"), .string("b")]),
+            "count": .number(2)
+        ])
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodableValue.self, from: data)
+        XCTAssertEqual(decoded, value)
+    }
+
+    func testAnyCodableValueEncodesNull() throws {
+        let value = AnyCodableValue.null
+        let data = try JSONEncoder().encode(value)
+        let str = String(data: data, encoding: .utf8)!
+        XCTAssertEqual(str, "null")
+    }
+
     func testAgentEventFailsOnUnknownType() {
         let json = """
         {"type":"unknown_event","data":"foo"}


### PR DESCRIPTION
## Summary

- Add `SidecarProtocol.swift` with all Codable types for the JSON-RPC protocol between Swift and the Node.js sidecar: commands (`RpcRequest`, `StartSessionParams`, `SendMessageParams`, `CancelSessionParams`), responses (`RpcResponse`, `SidecarMessage`), and streaming events (`AgentEvent` with 7 event types decoded via type discriminator)
- Add `SidecarProtocolTests.swift` with 25 encoding/decoding round-trip tests
- Use unified `number(Double)` case in `AnyCodableValue` since `JSONDecoder` cannot distinguish JSON `1` from `1.0`
- Add explicit guard for missing `params` in event notifications with descriptive error

## Test plan

- [x] All 25 `SidecarProtocolTests` pass
- [x] All existing `hydraTests` still pass
- [ ] User adds both files to Xcode targets manually (pbxproj limitation)

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)